### PR TITLE
feat: 요청마다 엑세스토큰 만료확인 요청을 보내고 API 응답으로 만료확인하기

### DIFF
--- a/src/auth.d.ts
+++ b/src/auth.d.ts
@@ -1,14 +1,14 @@
 // 참고: https://velog.io/@dosomething/Next-auth-%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84
 // 타입스크립트를 사용한다면 Session 타입을 확장해 주어야 한다.
 // src 폴더 하위에 두는 건, src 폴더가 빌드 대상이 되기 때문에 웹팩에게 해당 타입에 대해 알려주는 것이다.
-import NextAuth, { DefaultSession , User } from 'next-auth';
+import { DefaultSession , User } from 'next-auth';
 
 // 세션 객체
 declare module 'next-auth' {
   interface Session extends DefaultSession {
     user: {
       id?: string;
-      email?: string; // 이메일 정보
+      email: string; // 이메일 정보
     } & DefaultSession['user'];
     accessToken: string;
     accessTokenExpires: any;

--- a/src/component/layout/header/index.tsx
+++ b/src/component/layout/header/index.tsx
@@ -57,7 +57,7 @@ const Header = () => {
   const { data: sessionData, status: sessionStatus } = useSession();
   useEffect(() => {
     console.log("status:", JSON.stringify(sessionStatus));
-    if (!!sessionData?.error) {
+    if (sessionData?.error) {
       signOut({redirect:false, callbackUrl: "/"});
       router.push("/");
       console.log(sessionData.error);

--- a/src/component/main/userAside/index.tsx
+++ b/src/component/main/userAside/index.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import UserProfile from "@/component/main/userAside/userProfile";
 import {AsideBtnGroup, ChattingListDiv} from "@/component/main/userAside/userAside.style";
 import ChattingCard from "@/component/main/userAside/chattingCard";
+import {authedTokenAxios, refreshTokenAPI} from "@/lib/jwt";
+import {useSession} from "next-auth/react";
 
 export const UserAsideContainer = styled.div`
   width: 327px;
@@ -14,12 +16,27 @@ export const UserAsideContainer = styled.div`
   flex-direction: column;
   gap: 37px;
 `;
+
 const UserAside = () => {
+  const {data: sessionData, update: sessionUpdate} =useSession();
+  const tokenAxios = async () => {
+    const test_url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/token-test`
+    if (sessionData?.accessToken) {
+      try {
+        const response = await authedTokenAxios(sessionData.accessToken).post(test_url, "None")
+        console.log(response.data.message, "!")
+      } catch (error: any) {
+        console.log(`${error.response.data?.code}: ${error.response.data?.message}`)
+        refreshTokenAPI(sessionData, sessionUpdate).then(() => {})
+        }
+      }
+    }
+
   return (
     <UserAsideContainer>
       <UserProfile/>
       <AsideBtnGroup>
-        <button>팔로우</button>
+        <button onClick={tokenAxios}>팔로우</button>
         <button>채팅목록</button>
       </AsideBtnGroup>
       <ChattingListDiv>

--- a/src/lib/jwt.tsx
+++ b/src/lib/jwt.tsx
@@ -1,6 +1,17 @@
 import axios from "axios";
+import {decodeJwt} from "jose";
 
-export const authedTokenAxios = (accessToken: any, refreshToken: any) => {
+export const authedTokenAxios = (accessToken: any) => {
+  return axios.create({
+    // header를 여기서 설정해주면,
+    // 인스턴스를 실행할 때마다 매번 이 헤더가 자동으로 요청을 보낼 때 포함됨
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  })
+}
+
+export const refreshingTokenAxios = (accessToken: any, refreshToken: any) => {
   return axios.create({
     // header를 여기서 설정해주면,
     // 인스턴스를 실행할 때마다 매번 이 헤더가 자동으로 요청을 보낼 때 포함됨
@@ -9,3 +20,34 @@ export const authedTokenAxios = (accessToken: any, refreshToken: any) => {
     }
   })
 }
+
+export const refreshTokenAPI = async (data: any, update: any) => {
+  // access 토큰 만료시 재발급을 위한 요청
+  const test_url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/token-test`
+
+  await refreshingTokenAxios(data.accessToken, data.refreshToken)
+    .post(test_url, "None")
+    .then((res) => {
+      const refreshedAccessToken = res.data.data.accessToken;
+      update({ newToken: refreshedAccessToken });
+    })
+    .catch((reason) => {
+      console.log(`${reason.response.data?.code}: ${reason.response.data?.message}`)
+      update( {error: reason.response.data?.message} )
+    })
+}
+
+export const verifyTokenExp = (token: string) => {
+  // 토큰에서 만료기한 읽기
+  if (token) {
+    const decoded = decodeJwt(token)
+    return decoded.exp
+  } else return undefined
+};
+export const verifyTokenUserId = (token: string) => {
+  // 토큰에서 user_id 읽기
+  if (token) {
+    const decoded = decodeJwt(token)
+    return decoded.user_id
+  } else return undefined
+};


### PR DESCRIPTION
### 완료된 작업  

- #27 access 만료를 클라이언트에서 하던 구조를 요청을 보내고 만료 응답이 오면 재발급 API를 보내도록 수정
- 임시: 로그인 후 메인화면의 오른쪽 팔로우 버튼에 재발급 요청을 걸어놓음

### 개발중인 작업  

- #0

### 앞으로 해야할 작업  

- #0

### 공지사항  

