### PR TITLE
fix: docker-compose images rebuild error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Next.js ci/cd
+name: Next.js ci/cd using yarn and docker-compose
 
 on:
   push:
@@ -59,6 +59,7 @@ jobs:
           key: ${{ secrets.AWS_SSH_KEY }}
           port: 22
           script: |
+            cd /home/ubuntu/Menjil-FE
             sudo docker-compose down
             sudo docker system prune -a -f  
             
@@ -68,12 +69,6 @@ jobs:
             cd Menjil-FE
             touch .env  
             echo "${{secrets.env}}" > .env
-            sudo docker-compose up -d
+            sudo docker-compose up --build -d
 
-
-          # sudo docker kill $(sudo docker ps -qa)
-          # sudo docker rm $(docker ps -qa)
-          # sudo docker rmi $(docker images -q)
-          # sudo docker pull ${{ secrets.DOCKERHUB_REPO_FE }}:latest
-          # sudo docker-compose up -d
 


### PR DESCRIPTION
새로운 커밋이 추가되었음에도 불구하고 배포되었을 때 변경사항이 반영되지 않는 오류 수정입니다.
오류의 원인은, docker-compose가 올라갈 때, update 된 docker image가 아닌 기존에 존재하는 docker image가 사용되는 것이었으며,
docker-compose 명령어를 수정해서 해결했습니다.

p.s: 배포시 속도가 조금 더 소요됩니다.

